### PR TITLE
updated the opions button to open the options page. 

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -25,7 +25,7 @@ document.getElementById('url').addEventListener('change',
 
 function openOptions() {
   console.log('opening options');
-  chrome.tabs.create({url: "chrome-extension://iepikmnganjgdmieobnonlejjnnjoplg/resources/options.html" });
+  chrome.tabs.create({ 'url': 'chrome://extensions/?options=' + chrome.runtime.id });
 }
 
 document.getElementById("openOptions").addEventListener("click", openOptions);

--- a/resources/popup.html
+++ b/resources/popup.html
@@ -5,6 +5,7 @@
 
 Search:
 <select id="url">
+<option value="https://google.com/search?q=site:qualtrics.com/support ">Select a site to search</option>
  <option value="https://google.com/search?q=site:qualtrics.com/support ">Support Pages</option>
  <option value="http://odo.corp.qualtrics.com/wiki/index.php?search=">Knowledge Base</option>
  <option value="http://odo.corp.qualtrics.com/?b=ProductToolsUserSearch&autoUser=">User ID</option>


### PR DESCRIPTION
the previous options button doesn't work with the new update. This version uses chrome.runtime.id to populate the options URL instead of a static address. Additionally, the popup.html preference is saved with an onChange event but defaults to the top option in the html file. In the old file, this was support pages. If the user had their pref set at KB for example and wanted to change to support pages, they would have to click the drop down, select another option, then click again and select support pages because if they just selected support pages it wouldn't register a change in state and the pref would remain KB. 
