### PR TITLE
fixed default prefsite search

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,11 +1,10 @@
 chrome.runtime.onInstalled.addListener(function(details){
-    if(details.reason == "install"){
     	var key="prefSite";
   		var obj = {};
- 		obj[key] = 'https://google.com/search?q=site:qualtrics.com/support ';
+ 		obj[key] = '1https://google.com/search?q=site:qualtrics.com/support ';
  		chrome.storage.sync.set(obj, function() {
     		console.log('Initialized');
-})}});
+})});
 
 function resetDefaultSuggestion() {
   chrome.omnibox.setDefaultSuggestion({


### PR DESCRIPTION
When i added API support, i forgot to update the default prefsite URL created in background.js. this was causing the H in http:// to be cut off. I fixed that
