### PR TITLE
Quni ticket breakdown widget

### DIFF
--- a/js/TicketTable.js
+++ b/js/TicketTable.js
@@ -27,12 +27,12 @@ chrome.storage.sync.get({
 		console.log("In the table");
 		var firebaseRef = new Firebase("https://odo-enhanced.firebaseio.com/tickets");
 		function addColumn () {
-			$('table').eq(1).find("thead > tr").append('<th class="TicketDescription sorting" tabindex="0" aria-controls="9d48ef152aea2424d4a555b4c702e23e6" rowspan="1" colspan="1" aria-label="Description: activate to sort column ascending">Ticket Owner</th>');
+			$('table').eq(2).find("thead > tr").append('<th class="TicketDescription sorting" tabindex="0" aria-controls="9d48ef152aea2424d4a555b4c702e23e6" rowspan="1" colspan="1" aria-label="Description: activate to sort column ascending">Ticket Owner</th>');
 			var tblength = $('table').eq(1).find('tr').length;
 			firebaseRef.once("value", function(snapshot) {
 			    firebaseTickets = snapshot.val();
 				for (i=1; i<=tblength; i++){
-					var tid =$('table').eq(1).find("tbody > tr:nth-child("+i+") > td:nth-child(7) > a").attr('ticketid');
+					var tid =$('table').eq(2).find("tbody > tr:nth-child("+i+") > td:nth-child(7) > a").attr('ticketid');
 					if (firebaseTickets[tid]) {
 						var owner = firebaseTickets[tid]["owner"];
 						if (firebaseTickets[tid]["eid"] == EmployeeID){
@@ -41,7 +41,7 @@ chrome.storage.sync.get({
 					} else {
 						owner = 'You';
 					}
-					$('table').eq(1).find("tbody > tr:nth-child("+i+")").append("<td><strong>"+ owner +"</strong></td>");
+					$('table').eq(2).find("tbody > tr:nth-child("+i+")").append("<td><strong>"+ owner +"</strong></td>");
 				}
 			});
 

--- a/js/TicketTable.js
+++ b/js/TicketTable.js
@@ -3,10 +3,12 @@ var EmployeeID;
 var EmployeeName;
 chrome.storage.sync.get({
 	eid: "",
-	ename: ""
+	ename: "",
+	showQuniTickets: "",//Quni Ticket Breakdown
 }, function(items) {
 	EmployeeID = items.eid;
 	EmployeeName = items.ename;
+	showQuniTickets = items.showQuniTickets;
 	console.log(EmployeeID);
 	console.log(EmployeeName);
 
@@ -22,17 +24,24 @@ chrome.storage.sync.get({
 				ename: EmployeeName
 			});
 		}
+		var tableIndex;
+	if (showQuniTickets) {
+		tableIndex = 2;
+	}
+	else {
+		tableIndex = 1;
+	}
 
 	if ((window.location.href.indexOf('TicketViewer') == -1) && (((window.location.href.indexOf("a=Tickets") >= 0) && (window.location.href.indexOf("tid")==-1))|| (window.location.href.indexOf("TopNav=Tickets")>=0))){
 		console.log("In the table");
 		var firebaseRef = new Firebase("https://odo-enhanced.firebaseio.com/tickets");
 		function addColumn () {
-			$('table').eq(2).find("thead > tr").append('<th class="TicketDescription sorting" tabindex="0" aria-controls="9d48ef152aea2424d4a555b4c702e23e6" rowspan="1" colspan="1" aria-label="Description: activate to sort column ascending">Ticket Owner</th>');
-			var tblength = $('table').eq(1).find('tr').length;
+			$('table').eq(tableIndex).find("thead > tr").append('<th class="TicketDescription sorting" tabindex="0" aria-controls="9d48ef152aea2424d4a555b4c702e23e6" rowspan="1" colspan="1" aria-label="Description: activate to sort column ascending">Ticket Owner</th>');
+			var tblength = $('table').eq(tableIndex).find('tr').length;
 			firebaseRef.once("value", function(snapshot) {
 			    firebaseTickets = snapshot.val();
 				for (i=1; i<=tblength; i++){
-					var tid =$('table').eq(2).find("tbody > tr:nth-child("+i+") > td:nth-child(7) > a").attr('ticketid');
+					var tid =$('table').eq(tableIndex).find("tbody > tr:nth-child("+i+") > td:nth-child(7) > a").attr('ticketid');
 					if (firebaseTickets[tid]) {
 						var owner = firebaseTickets[tid]["owner"];
 						if (firebaseTickets[tid]["eid"] == EmployeeID){
@@ -41,7 +50,7 @@ chrome.storage.sync.get({
 					} else {
 						owner = 'You';
 					}
-					$('table').eq(2).find("tbody > tr:nth-child("+i+")").append("<td><strong>"+ owner +"</strong></td>");
+					$('table').eq(tableIndex).find("tbody > tr:nth-child("+i+")").append("<td><strong>"+ owner +"</strong></td>");
 				}
 			});
 

--- a/js/options.js
+++ b/js/options.js
@@ -24,6 +24,7 @@ function save_options() {
 	var spamCount = document.getElementById('SpamCount').value;
 	var blockSpam = document.getElementById('BlockSpam').checked;
 	var omniSearch = document.getElementById('OmniSearch').checked;
+	var quniTickets = document.getElementById('QuniTickets').checked;
 	chrome.storage.sync.set({
 		em: createEmail,
 		cl: createClinic,
@@ -48,7 +49,8 @@ function save_options() {
 		hidePosts: hideSquawkPosts,
 		spamCount: spamCount,
 		blockSpam: blockSpam,
-		omniSearch: omniSearch
+		omniSearch: omniSearch,
+		showQuniTickets: quniTickets
 	}, function() {
 		// Update status to let the user know options were saved.
 		var status = document.getElementById('status');
@@ -86,7 +88,8 @@ function restore_options() {
 		hidePosts: false,
 		spamCount: 25,
 		blockSpam: true,
-		omniSearch: true
+		omniSearch: true,
+		showQuniTickets: true
 	}, function(items) {
 		document.getElementById('EmailButton').checked = items.em;
 		document.getElementById('ClinicButton').checked = items.cl;
@@ -112,6 +115,7 @@ function restore_options() {
 		document.getElementById('SpamCount').value = items.spamCount;
 		document.getElementById('BlockSpam').checked = items.blockSpam;
 		document.getElementById('OmniSearch').checked = items.omniSearch;
+		document.getElementById('QuniTickets').checked = items.showQuniTickets;
 		makeOpaque();
 	});
 }

--- a/js/quni.js
+++ b/js/quni.js
@@ -58,6 +58,7 @@ function getVars() {
 		tm: "", // Current Theme
 		tg: 3700, //Ticket Goal
 		td: "",//Ticket Goal Date
+		showQuniTickets: "",//Quni Ticket BReakdown
 		tips: true,
 		ename: "",
 		panels: false,
@@ -91,6 +92,8 @@ function getVars() {
 		hidePosts = items.hidePosts;
 		spamCount = items.spamCount;
 		blockSpam = items.blockSpam;
+		showQuniTickets = items.showQuniTickets;
+		console.log("Show em? " + showQuniTickets);
 		addons();
 	});
 }
@@ -901,6 +904,10 @@ function addons() {
 	if (PanelsTabOn) {
 		customTabs.addPanels();
 	}
+	//QUNI TICKET BREAKOUT
+	if (showQuniTickets) {
+		addDashTable();
+	}
 	//SNIPPETS AND CHROME OPTIONS
 	if ((urlParams["a"] == "Home") || (urlParams["a"] == null && urlParams['TopNav'] != "Tickets" && urlParams['TopNav'] != "Company" && urlParams['TopNav'] != "Reports")) {
 		customTabs.addChromeOptions();
@@ -966,6 +973,7 @@ function addons() {
 	//SPF CHECKER
 	if (urlParams["b"] == "RSBrandProfile"){
 		window.setTimeout(OdoSPFCheck, 300);
+
 	}
 }
 /*****************************************************
@@ -1279,7 +1287,5 @@ function assignQueue(ticketCode, ticketTier) {
 	return assignedQueue;
 
 }
-
-addDashTable();
 
 console.log("Success! Odo Enhanced Works!");

--- a/js/quni.js
+++ b/js/quni.js
@@ -58,7 +58,7 @@ function getVars() {
 		tm: "", // Current Theme
 		tg: 3700, //Ticket Goal
 		td: "",//Ticket Goal Date
-		showQuniTickets: "",//Quni Ticket BReakdown
+		showQuniTickets: "",//Quni Ticket Breakdown
 		tips: true,
 		ename: "",
 		panels: false,

--- a/views/options.html
+++ b/views/options.html
@@ -25,6 +25,11 @@
 				<span>Design Resources (Theme Design Only)</span>
 			</label>
 			<br>
+			<label class='CheckLabel' for='QuniTickets'>
+				<input class='Check' value='qunitickets' id='QuniTickets' type='checkbox' />
+				<span>Show Tickets Breakdown in Quni Inbox</span>
+			</label>
+			<br>
 		</div>
 		<div class='OptionSection'>Buttons</br>
 			<div class='Description'>Add Custom buttons to Odo</div>


### PR DESCRIPTION
Added a Calltrics-type breakdown widget at the top of the My Tickets page. This widget breaks out your recommended email tickets into the proper specialty or client tier.

Widget code lives in quni.js.

TicketTable.js had to be updated so the "Ticket Owner" would be appended to the correct table.

options.html and options.js were updated so extension users can toggle this table on and off.
