### PR TITLE
Added ability to hide unused specialty queues

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -24,7 +24,16 @@ function save_options() {
 	var spamCount = document.getElementById('SpamCount').value;
 	var blockSpam = document.getElementById('BlockSpam').checked;
 	var omniSearch = document.getElementById('OmniSearch').checked;
+	//Quni Ticket Breakdown
 	var quniTickets = document.getElementById('QuniTickets').checked;
+	var siQueue = document.getElementById('SIQueue').checked;
+	var taQueue = document.getElementById('TAQueue').checked;
+	var three60Queue = document.getElementById('360Queue').checked;
+	var eeQueue = document.getElementById('EEQueue').checked;
+	var themesQueue = document.getElementById('ThemesQueue').checked;
+	var vocQueue = document.getElementById('VocQueue').checked;
+	var statQueue = document.getElementById('StatQueue').checked;
+	var intQueue = document.getElementById('IntQueue').checked;
 	chrome.storage.sync.set({
 		em: createEmail,
 		cl: createClinic,
@@ -50,7 +59,16 @@ function save_options() {
 		spamCount: spamCount,
 		blockSpam: blockSpam,
 		omniSearch: omniSearch,
-		showQuniTickets: quniTickets
+		//Quni Ticket Breakdown
+		showQuniTickets: quniTickets,
+		showSIQueue: siQueue,
+		showTAQueue: taQueue,
+		show360Queue: three60Queue,
+		showEEQueue: eeQueue,
+		showThemesQueue: themesQueue,
+		showVocQueue: vocQueue,
+		showStatQueue: statQueue,
+		showIntQueue: intQueue
 	}, function() {
 		// Update status to let the user know options were saved.
 		var status = document.getElementById('status');
@@ -89,7 +107,16 @@ function restore_options() {
 		spamCount: 25,
 		blockSpam: true,
 		omniSearch: true,
-		showQuniTickets: true
+		//Quni Ticket breakdowns
+		showQuniTickets: false,
+		showSIQueue: false,
+		showTAQueue: false,
+		show360Queue: false,
+		showEEQueue: false,
+		showThemesQueue: false,
+		showVocQueue: false,
+		showStatQueue: false,
+		showIntQueue: false
 	}, function(items) {
 		document.getElementById('EmailButton').checked = items.em;
 		document.getElementById('ClinicButton').checked = items.cl;
@@ -115,7 +142,16 @@ function restore_options() {
 		document.getElementById('SpamCount').value = items.spamCount;
 		document.getElementById('BlockSpam').checked = items.blockSpam;
 		document.getElementById('OmniSearch').checked = items.omniSearch;
+		//Quni Ticket Breakdown
 		document.getElementById('QuniTickets').checked = items.showQuniTickets;
+		document.getElementById('SIQueue').checked = items.showSIQueue;
+		document.getElementById('TAQueue').checked = items.showTAQueue;
+		document.getElementById('360Queue').checked = items.show360Queue;
+		document.getElementById('EEQueue').checked = items.showEEQueue;
+		document.getElementById('ThemesQueue').checked = items.showThemesQueue;
+		document.getElementById('VocQueue').checked = items.showVocQueue;
+		document.getElementById('StatQueue').checked = items.showStatQueue;
+		document.getElementById('IntQueue').checked = items.showIntQueue;
 		makeOpaque();
 	});
 }

--- a/js/options.js
+++ b/js/options.js
@@ -26,14 +26,14 @@ function save_options() {
 	var omniSearch = document.getElementById('OmniSearch').checked;
 	//Quni Ticket Breakdown
 	var quniTickets = document.getElementById('QuniTickets').checked;
-	var siQueue = document.getElementById('SIQueue').checked;
-	var taQueue = document.getElementById('TAQueue').checked;
-	var three60Queue = document.getElementById('360Queue').checked;
-	var eeQueue = document.getElementById('EEQueue').checked;
-	var themesQueue = document.getElementById('ThemesQueue').checked;
-	var vocQueue = document.getElementById('VocQueue').checked;
-	var statQueue = document.getElementById('StatQueue').checked;
-	var intQueue = document.getElementById('IntQueue').checked;
+	var showSIQueue = document.getElementById('SIQueue').checked;
+	var showTAQueue = document.getElementById('TAQueue').checked;
+	var show360Queue = document.getElementById('360Queue').checked;
+	var showEEQueue = document.getElementById('EEQueue').checked;
+	var showThemesQueue = document.getElementById('ThemesQueue').checked;
+	var showVocQueue = document.getElementById('VocQueue').checked;
+	var showStatQueue = document.getElementById('StatQueue').checked;
+	var showIntQueue = document.getElementById('IntQueue').checked;
 	chrome.storage.sync.set({
 		em: createEmail,
 		cl: createClinic,
@@ -61,14 +61,14 @@ function save_options() {
 		omniSearch: omniSearch,
 		//Quni Ticket Breakdown
 		showQuniTickets: quniTickets,
-		showSIQueue: siQueue,
-		showTAQueue: taQueue,
-		show360Queue: three60Queue,
-		showEEQueue: eeQueue,
-		showThemesQueue: themesQueue,
-		showVocQueue: vocQueue,
-		showStatQueue: statQueue,
-		showIntQueue: intQueue
+		showSIQueue: showSIQueue,
+		showTAQueue: showTAQueue,
+		show360Queue: show360Queue,
+		showEEQueue: showEEQueue,
+		showThemesQueue: showThemesQueue,
+		showVocQueue: showVocQueue,
+		showStatQueue: showStatQueue,
+		showIntQueue: showIntQueue
 	}, function() {
 		// Update status to let the user know options were saved.
 		var status = document.getElementById('status');

--- a/js/quni.js
+++ b/js/quni.js
@@ -59,6 +59,14 @@ function getVars() {
 		tg: 3700, //Ticket Goal
 		td: "",//Ticket Goal Date
 		showQuniTickets: "",//Quni Ticket Breakdown
+		showSIQueue: "", 
+		showTAQueue: "",
+		show360Queue: "",
+		showEEQueue: "",
+		showThemesQueue: "",
+		showVocQueue: "",
+		showStatQueue: "",
+		showIntQueue: "",
 		tips: true,
 		ename: "",
 		panels: false,
@@ -93,6 +101,14 @@ function getVars() {
 		spamCount = items.spamCount;
 		blockSpam = items.blockSpam;
 		showQuniTickets = items.showQuniTickets;
+		showSIQueue = items.showSIQueue;
+		showTAQueue = items.showTAQueue;
+		show360Queue = items.show360Queue;
+		showEEQueue = items.showEEQueue;
+		showThemesQueue = items.showThemesQueue;
+		showVocQueue = items.showVocQueue;
+		showStatQueue = items.showStatQueue;
+		showIntQueue = items.showIntQueue;
 		addons();
 	});
 }
@@ -1078,9 +1094,6 @@ function addDashTable() {
 
 	if ((urlParams["TopNav"] == "Tickets" || urlParams["a"] == "Tickets" ) && (urlParams["b"] == undefined || urlParams["b"] == "TicketsSupportInBox")) {
 		var menu = $('.menu-items');
-		//$('#BodyContent').prepend("Hello");
-
-		$('.PageSectionToolbar').after('<h2>Available Tickets Breakdown</h2><div class="container" id="DashTableOuter" style="max-width: 99%; margin-top: 10px; padding: 0px;"><div class="table-responsive"><style>#RecommendedTable > thead > tr > th {text-align: center; padding: 10px 15px 10px 3px; font-weight: normal; border-bottom: 1px solid #C7C7C7; overflow: hidden;} #RecommendedTable > tbody > tr > td {text-align: center; padding-left: 0px; } .right-wall { border-right: 1px solid #C7C7C7; }</style><table id="RecommendedTable" class="Green dataTable table" style="table-layout: fixed;"><thead><tr><th id="StudentHead">Student</th><th id="ZRHead">Zebra/ Rhino</th><th id="TigerHead">Tiger</th><th id="DLHead" class="right-wall">Dragon/ Lion</th><th id="SIHead">SI</th><th id="TAHead">TA</th><th id="360Head">360</th><th id="EEHead">EE</th><th id="ThemesHead">Themes</th><th id="VCHead">VoC</th><th id="SWHead">Statwing</th><th id="IntegrationsHead">Int</th></tr></thead><tbody><tr class="text-center"><td id="StudentItem">0</td><td id="ZRItem">0</td><td id="TigerItem">0</td><td id="DLItem" class="right-wall">0</td><td id="SIItem">0</td><td id="TAItem">0</td><td id="360Item">0</td><td id="EEItem">0</td><td id="ThemesItem">0</td><td id="VCItem">0</td><td id="SWItem">0</td><td id="IntegrationsItem">0</td></tr></tbody></table></div></div>');
 
 		var Tickets;
 
@@ -1109,45 +1122,68 @@ function addDashTable() {
 			"SI": {
 				"head": "SIHead",
 				"item": "SIItem",
-				"count": 0
+				"count": 0,
+				"show": showSIQueue
 			},
 			"TA": {
 				"head": "TAHead",
 				"item": "TAItem",
-				"count": 0
+				"count": 0,
+				"show": showTAQueue
 			},
 			"360": {
 				"head": "360Head",
 				"item": "360Item",
-				"count": 0
+				"count": 0,
+				"show": show360Queue
 			},
 			"EE": {
 				"head": "EEHead",
 				"item": "EEItem",
-				"count": 0
+				"count": 0,
+				"show": showEEQueue
 			},
 			"Themes": {
 				"head": "ThemesHead",
 				"item": "ThemesItem",
-				"count": 0
+				"count": 0,
+				"show": showThemesQueue
 			},
 			"VC": {
 				"head": "VCHead",
 				"item": "VCItem",
-				"count": 0
+				"count": 0,
+				"show": showVocQueue
 			},
 			"SW": {
 				"head": "SWHead",
 				"item": "SWItem",
-				"count": 0
+				"count": 0,
+				"show": showStatQueue
 			},
 			"Integrations": {
 				"head": "IntegrationsHead",
 				"item": "IntegrationsItem",
-				"count": 0
+				"count": 0,
+				"show": showIntQueue
 			}
 
 		};
+
+		$('.PageSectionToolbar').after('<div id="TicketBreakdownDiv"></div>');
+		var ticketBreakdownURL = chrome.extension.getURL('views/TicketBreakdown.html');
+
+		$('#TicketBreakdownDiv').load(ticketBreakdownURL, function() {
+			var queues = Object.keys(QueueObjects);
+			for (var i=0; i<queues.length; i++) {
+				var queue = queues[i];
+				if (QueueObjects[queue].show === false) {
+					$("#" + QueueObjects[queue]["head"]).hide();
+					$("#" + QueueObjects[queue]["item"]).hide();
+			}
+		}
+		});
+
 
 		chrome.storage.sync.get({eid: ""}, function (items) {
 			$.ajax({
@@ -1255,6 +1291,7 @@ function assignQueue(ticketCode, ticketTier) {
 		}
 
 	}
+	console.log(assignedQueue);
 	return assignedQueue;
 
 }

--- a/js/quni.js
+++ b/js/quni.js
@@ -1291,7 +1291,6 @@ function assignQueue(ticketCode, ticketTier) {
 		}
 
 	}
-	console.log(assignedQueue);
 	return assignedQueue;
 
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 2,
 	"name": "Odo Enhanced",
 	"description": "Favicons, Buttons, Reactions, and more",
-	"version": "1.8.19",
+	"version": "1.8.20",
 	"omnibox": {
     	"keyword": ";q"
 	},
@@ -29,6 +29,7 @@
 		"css/greyAlerts.css",
 		"css/search.css",
 		"views/options.html",
+		"views/TicketBreakdown.html",
 		"css/starjedihollow-webfont.ttf"
 	],
 	"icons": {

--- a/views/TicketBreakdown.html
+++ b/views/TicketBreakdown.html
@@ -1,0 +1,100 @@
+<h2>Available Tickets Breakdown</h2>
+<div class="container" id="DashTableOuter" style="max-width: 99%; margin-top: 10px; padding: 0px;">
+<div class="table-responsive">
+<style>
+	#RecommendedTable > thead > tr > th { 
+		text-align: center;
+		padding: 10px 15px 10px 3px;
+		font-weight: normal;
+		border-bottom: 1px solid #C7C7C7;
+		overflow: hidden; 
+	} 
+	#RecommendedTable > tbody > tr > td { 
+		text-align: center;
+		padding-left: 0px;
+	}
+	.right-wall {
+		border-right: 1px solid #C7C7C7;
+	}
+</style>
+<table id="RecommendedTable" class="Green dataTable table" style="table-layout: fixed; min-width: 75%; width: auto">
+	<!--<tr>
+		<thead>
+			<h4>Standard & Specialty Queues</h4>
+		</thead>
+		
+	</tr>-->
+	<thead>
+		<tr>
+			<th id="StudentHead">Student</th>
+			<th id="ZRHead">Zebra/ Rhino</th>
+			<th id="TigerHead">Tiger</th>
+			<th id="DLHead" class="right-wall">Dragon/ Lion</th>
+			<th id="SIHead">SI</th>
+			<th id="TAHead">TA</th>
+			<th id="360Head">360</th>
+			<th id="EEHead">EE</th>
+			<th id="ThemesHead">Themes</th>
+			<th id="VCHead">VoC</th>
+			<th id="SWHead">Statwing</th>
+			<th id="IntegrationsHead">Int</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr class="text-center">
+			<td id="StudentItem" style="font-weight: normal;">0</td>
+			<td id="ZRItem">0</td>
+			<td id="TigerItem">0</td>
+			<td id="DLItem" class="right-wall">0</td>
+			<td id="SIItem">0</td>
+			<td id="TAItem">0</td>
+			<td id="360Item">0</td>
+			<td id="EEItem">0</td>
+			<td id="ThemesItem">0</td>
+			<td id="VCItem">0</td>
+			<td id="SWItem">0</td>
+			<td id="IntegrationsItem">0</td>
+		</tr>
+	</tbody>
+<!--
+	<tbody>
+		<tr>
+			<td style="display: block; width:180px; text-align:left;"">Language Queues</td>
+		</tr>
+	</tbody>
+	<thead>
+		<tr>
+			<th id="StudentHead">Student</th>
+			<th id="ZRHead">Zebra/ Rhino</th>
+			<th id="TigerHead">Tiger</th>
+			<th id="DLHead" class="right-wall">Dragon/ Lion</th>
+			<th id="SIHead">SI</th>
+			<th id="TAHead">TA</th>
+			<th id="360Head">360</th>
+			<th id="EEHead">EE</th>
+			<th id="ThemesHead">Themes</th>
+			<th id="VCHead">VoC</th>
+			<th id="SWHead">Statwing</th>
+			<th id="IntegrationsHead">Int</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr class="text-center">
+			<td id="StudentItem">0</td>
+			<td id="ZRItem">0</td>
+			<td id="TigerItem">0</td>
+			<td id="DLItem" class="right-wall">0</td>
+			<td id="SIItem">0</td>
+			<td id="TAItem">0</td>
+			<td id="360Item">0</td>
+			<td id="EEItem">0</td>
+			<td id="ThemesItem">0</td>
+			<td id="VCItem">0</td>
+			<td id="SWItem">0</td>
+			<td id="IntegrationsItem">0</td>
+		</tr>
+	</tbody>
+-->
+</table>
+</div>
+</div>

--- a/views/options.html
+++ b/views/options.html
@@ -30,6 +30,43 @@
 				<span>Show Tickets Breakdown in Quni Inbox</span>
 			</label>
 			<br>
+			<div id="TicketBreakdownOptions">
+				<div class="Description" id="SpecialtyQueuesDescription">Which specialty queues are you a part of?</div>
+				<div class="SpecialtyQueues">
+				<label class='CheckLabel QueueLabel' for='SIQueue'>
+					<input class="Check" id="SIQueue" type='checkbox' />
+					<span class="Queue">SI</span>
+				</label>
+				<label class='CheckLabel QueueLabel' for='TAQueue'>
+					<input class="Check" id='TAQueue' type='checkbox' />
+					<span class="Queue">TA</span>
+				</label>
+				<label class='CheckLabel QueueLabel' for='360Queue'>
+					<input class="Check" id='360Queue' type='checkbox' />
+					<span class="Queue">360</span>
+				</label>
+				<label class='CheckLabel QueueLabel' for='EEQueue'>
+					<input class="Check" id='EEQueue' type='checkbox' />
+					<span class="Queue">EE</span>
+				</label>
+				<label class='CheckLabel QueueLabel' for='ThemesQueue'>
+					<input class="Check" id='ThemesQueue' type='checkbox' />
+					<span class="Queue">Themes</span>
+				</label>
+				<label class='CheckLabel QueueLabel' for='VocQueue'>
+					<input class="Check" id='VocQueue' type='checkbox' />
+					<span class="Queue">VoC</span>
+				</label>
+				<label class='CheckLabel QueueLabel' for='StatQueue'>
+					<input class="Check" id='StatQueue' type='checkbox' />
+					<span class="Queue">Statwing</span>
+				</label>
+				<label class='CheckLabel QueueLabel' for='IntQueue'>
+					<input class="Check" id='IntQueue' type='checkbox' />
+					<span class="Queue">Int</span>
+				</label>
+				</div>
+			</div>
 		</div>
 		<div class='OptionSection'>Buttons</br>
 			<div class='Description'>Add Custom buttons to Odo</div>
@@ -180,6 +217,12 @@ body {
 	padding: 10px;
 	text-transform: none;
 }
+#SpecialtyQueuesDescription {
+	padding-bottom: 0px;
+}
+.SpecialtyQueues {
+	padding: 3px;
+}
 #status {
 	margin-top: 30px;
 }
@@ -192,7 +235,7 @@ label {
 .CheckLabel span {
 	padding: 3px 12px;
 	display: inline-block;
-	margin: 3px auto;
+	margin: 16px 0px 7px 0px;
 	text-transform: none;
 	border: 2px solid #ddd;
 	border-radius: 15px;
@@ -200,6 +243,15 @@ label {
 	transition: .3s;
 	cursor: pointer;
 	background-color: #cacaca;
+}
+.CheckLabel .Queue {
+	width: auto;
+	padding: 3px 6px;
+}
+.QueueLabel {
+	display: inline;
+	font-size: 11px;
+	margin: 0px 3px;
 }
 input[type=text] {
 	width: 90%;
@@ -222,13 +274,12 @@ input[type=checkbox]:checked + span {
 	color: #fff;
 	border-color: #14b375;
 }
-.NonCheckLabel {
-}
 input[type=checkbox], select, input[type=color] {
 	float: right;
 }
 input[type=checkbox] {
 	visibility: hidden;
+	display:none;
 }
 .OtherType {
 	text-align: left;


### PR DESCRIPTION
Added buttons to the options page that allows Quni members to hide the queues they are not a member of. This is building towards adding in language queues.

Pulled HTML for the recommended ticket table out into a separate file, instead of loading directly in the JS. This makes the HTML much easier to edit.
HTML is now loaded from views/TicketBreakdown.html using jQuery's async load() function. 